### PR TITLE
Fix error attempt to index local 'unitLevelString'

### DIFF
--- a/Core/Translators/Tooltips/UnitTooltipTranslator.lua
+++ b/Core/Translators/Tooltips/UnitTooltipTranslator.lua
@@ -53,6 +53,10 @@ local function parseUnitTooltipLines(unitTooltipLines)
     end
 
     local function parseUnitLevelString(unitLevelString)
+	    if not unitLevelString then
+            return nil, nil, nil, false
+		end
+		
         local level, unitType, rank, isPet = nil, nil, nil, false
         local stringParts = {}
 


### PR DESCRIPTION
This will avoid attempts to index a nil value and return 'nil' instead of expected data if the string cannot be parsed into components.