### PR TITLE
fix: main frame buttons are shifted if ElvUI is active

### DIFF
--- a/Core/Translators/Frames/MainFrameTranslator.lua
+++ b/Core/Translators/Frames/MainFrameTranslator.lua
@@ -59,7 +59,7 @@ end
 function translator:Init()
     UpdateTextWithTranslation(GameMenuFrame.Header.Text, GetTranslatedGlobalString)
 
-    hooksecurefunc(GameMenuFrame, "InitButtons", function(frame)
+    hooksecurefunc(GameMenuFrame, "Layout", function(frame)
         for buttonFrame in frame.buttonPool:EnumerateActive() do
             UpdateTextWithTranslation(buttonFrame, GetTranslatedGlobalString)
         end


### PR DESCRIPTION
Hi! I've noticed that the ElvUI button in the Main Menu overlaps with other buttons because ElvUI reorders them by text, which fails due to translation.

![image](https://github.com/user-attachments/assets/275a7169-d91e-49b5-8a62-a18bfd69b83f)

This can be fixed by changing the hook function from `InitButtons` to `Layout`. But I'd appreciate your review of potential side effects this hook change may introduce.
