### PR TITLE
Fix: Remove BackButton functionality from map legend

### DIFF
--- a/Core/Translators/Frames/MapFrameTranslator.lua
+++ b/Core/Translators/Frames/MapFrameTranslator.lua
@@ -30,7 +30,6 @@ end
 
 local function TranslateMapLegend()
     UpdateTextWithTranslation(QuestMapFrame.MapLegend.TitleText, GetTranslatedGlobalString)
-    UpdateTextWithTranslation(QuestMapFrame.MapLegend.BackButton.Text, GetTranslatedGlobalString)
     for _, categoryFrame in pairs({ QuestMapFrame.MapLegend.ScrollFrame.ScrollChild:GetChildren() }) do
         for _, layoutTable in pairs({ categoryFrame:GetLayoutChildren() }) do
             for _, legendItemFrame in ipairs(layoutTable) do


### PR DESCRIPTION
Description:
Blizzard removed the BackButton from the map legend in patch 11.1. This commit removes the code in WowUkrainizer that was referencing the removed BackButton, preventing errors. Also the translation of the BackButton text was removed.

Changes:
- Removed BackButton reference from TranslateMapLegend() in MapFrameTranslator.lua.
- Removed BackButton translation.

Testing:
- Verified that the error no longer occurs.
- Verified that other translations in the map legend are working.